### PR TITLE
Changed permission request code to avoid collision with other plugin

### DIFF
--- a/android/src/main/java/io/flutter/plugins/flutterexifrotation/FlutterExifRotationPlugin.java
+++ b/android/src/main/java/io/flutter/plugins/flutterexifrotation/FlutterExifRotationPlugin.java
@@ -36,7 +36,7 @@ public class FlutterExifRotationPlugin implements MethodCallHandler, PluginRegis
     private final PermissionManager permissionManager;
 
 
-    static final int REQUEST_EXTERNAL_IMAGE_STORAGE_PERMISSION = 2344;
+    static final int REQUEST_EXTERNAL_IMAGE_STORAGE_PERMISSION = 23483;
 
     interface PermissionManager {
         boolean isPermissionGranted(String permissionName);


### PR DESCRIPTION
The plugin image_picker uses the same permission request code on android. This can lead to problems, that one of the two plugins gets its onRequestPermissionsResult callback first and "steals" the result from the other.