### PR TITLE
Fixes images overwriting when using multiple image picker on iOS

### DIFF
--- a/ios/Classes/SwiftFlutterExifRotationPlugin.swift
+++ b/ios/Classes/SwiftFlutterExifRotationPlugin.swift
@@ -22,7 +22,8 @@ public class SwiftFlutterExifRotationPlugin: NSObject, FlutterPlugin {
             if let updatedImage = image?.updateImageOrientationUpSide() {
                 
                 let fileManager = FileManager.default
-                let paths = (NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0] as NSString).appendingPathComponent("apple.jpg")
+                var file_name = NSURL(fileURLWithPath: imagePath).lastPathComponent!
+                let paths = (NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0] as NSString).appendingPathComponent(file_name)
                 // let image = UIImage(named: "apple.jpg")
                 print(paths)
                 let imageData = updatedImage.jpegData(compressionQuality: 0.8); fileManager.createFile(atPath: paths as String, contents: imageData, attributes: nil)


### PR DESCRIPTION
Because the swift code used a static image name, when this plugin was used multiple times in a row it overwrote the old images. This fixes that by using the file name of the image as the file name of the rotated image.