### PR TITLE
Null Safety Support

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,7 +15,7 @@ class MyApp extends StatefulWidget {
 
 /// The class with the scaffold
 class _MyAppState extends State<MyApp> {
-  File _image;
+  File? _image;
   final picker = ImagePicker();
 
   Future getImage() async {
@@ -61,7 +61,7 @@ class _MyAppState extends State<MyApp> {
         body: new Center(
           child: _image == null
               ? new Text('No image selected.')
-              : new Image.file(_image),
+              : new Image.file(_image!),
         ),
         persistentFooterButtons: <Widget>[
           new FloatingActionButton(

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the flutter_exif_rotation plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.13.0 <2.0.0"
 
 dependencies:
@@ -18,7 +18,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  image_picker: ^0.6.7+12
+  image_picker: ^0.7.2
   flutter_exif_rotation:
     path: ../
 

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -18,7 +18,7 @@ void main() {
     expect(
       find.byWidgetPredicate(
         (Widget widget) =>
-            widget is Text && widget.data.startsWith('Running on:'),
+            widget is Text && widget.data!.startsWith('Running on:'),
       ),
       findsOneWidget,
     );

--- a/lib/flutter_exif_rotation.dart
+++ b/lib/flutter_exif_rotation.dart
@@ -9,19 +9,19 @@ class FlutterExifRotation {
   static const MethodChannel _channel =
       const MethodChannel('flutter_exif_rotation');
 
-  static Future<String> get platformVersion async {
-    final String version = await _channel.invokeMethod('getPlatformVersion');
+  static Future<String?> get platformVersion async {
+    final String? version = await _channel.invokeMethod('getPlatformVersion');
     return version;
   }
 
   /// Get the [path] of the image and fix the orientation.
   /// Return the [File] with the exif data fixed
-  static Future<File> rotateImage({@required String path}) async {
+  static Future<File> rotateImage({required String path}) async {
     assert(path != null);
-    String filePath = await _channel.invokeMethod(
+    String filePath = await (_channel.invokeMethod(
       'rotateImage',
       <String, dynamic>{'path': path, 'save': false},
-    );
+    ) as FutureOr<String>);
 
     return new File(filePath);
   }
@@ -29,12 +29,12 @@ class FlutterExifRotation {
   /// Get the [path] of the image, fix the orientation and
   /// saves the file in the device.
   /// Return the [File] with the exif data fixed
-  static Future<File> rotateAndSaveImage({@required String path}) async {
+  static Future<File> rotateAndSaveImage({required String path}) async {
     assert(path != null);
-    String filePath = await _channel.invokeMethod(
+    String filePath = await (_channel.invokeMethod(
       'rotateImage',
       <String, dynamic>{'path': path, 'save': true},
-    );
+    ) as FutureOr<String>);
 
     return new File(filePath);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/NGhebreial/flutter_exif_rotation
 repository: https://github.com/NGhebreial/flutter_exif_rotation
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.13.0 <2.0.0"
 
 dependencies:


### PR DESCRIPTION
This PR simply ran `dart migrate` on both the library and the examples, had to update `image_picker` dependency to `0.7.2`