### PR TITLE
Fixing OutOfMemory exception when rotating multiple images

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,5 +48,4 @@ android {
 dependencies {
     implementation "androidx.exifinterface:exifinterface:1.3.3"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,4 +48,5 @@ android {
 dependencies {
     implementation "androidx.exifinterface:exifinterface:1.3.3"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
 }

--- a/android/src/main/kotlin/io/flutter/plugins/flutterexifrotation/FlutterExifRotationPlugin.kt
+++ b/android/src/main/kotlin/io/flutter/plugins/flutterexifrotation/FlutterExifRotationPlugin.kt
@@ -10,17 +10,17 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import kotlinx.coroutines.*
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 
 /**
  * FlutterExifRotationPlugin
  */
 class FlutterExifRotationPlugin : FlutterPlugin, MethodCallHandler {
     private var applicationContext: Context? = null
+    private val mainScope = CoroutineScope(Dispatchers.Main)
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         applicationContext = binding.applicationContext
@@ -33,16 +33,16 @@ class FlutterExifRotationPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
-        runOnBackground {
             when (call.method) {
                 "rotateImage" -> {
-                    launchRotateImage(call, result)
+                    mainScope.launch {
+                        launchRotateImage(call, result)
+                    }
                 }
                 else -> {
                     result.notImplemented()
                 }
             }
-        }
     }
 
     private fun launchRotateImage(call: MethodCall, result: MethodChannel.Result) {
@@ -89,14 +89,6 @@ class FlutterExifRotationPlugin : FlutterPlugin, MethodCallHandler {
 
     companion object {
         private const val channelName = "flutter_exif_rotation"
-
-        val threadPool: ExecutorService = Executors.newCachedThreadPool()
-
-        inline fun runOnBackground(crossinline block: () -> Unit) {
-            threadPool.execute {
-                block()
-            }
-        }
 
         private fun rotate(source: Bitmap, angle: Float): Bitmap {
             val matrix = Matrix()

--- a/android/src/main/kotlin/io/flutter/plugins/flutterexifrotation/FlutterExifRotationPlugin.kt
+++ b/android/src/main/kotlin/io/flutter/plugins/flutterexifrotation/FlutterExifRotationPlugin.kt
@@ -10,18 +10,17 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
-import kotlinx.coroutines.*
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 /**
  * FlutterExifRotationPlugin
  */
 class FlutterExifRotationPlugin : FlutterPlugin, MethodCallHandler {
     private var applicationContext: Context? = null
-    private val mainScope = CoroutineScope(Dispatchers.Main)
-
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         applicationContext = binding.applicationContext
         val methodChannel = MethodChannel(binding.binaryMessenger, channelName)
@@ -33,16 +32,16 @@ class FlutterExifRotationPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        runOnBackground {
             when (call.method) {
                 "rotateImage" -> {
-                    mainScope.launch {
-                        launchRotateImage(call, result)
-                    }
+                    launchRotateImage(call, result)
                 }
                 else -> {
                     result.notImplemented()
                 }
             }
+        }
     }
 
     private fun launchRotateImage(call: MethodCall, result: MethodChannel.Result) {
@@ -89,6 +88,14 @@ class FlutterExifRotationPlugin : FlutterPlugin, MethodCallHandler {
 
     companion object {
         private const val channelName = "flutter_exif_rotation"
+
+        val threadPool: ExecutorService = Executors.newSingleThreadExecutor()
+
+        inline fun runOnBackground(crossinline block: () -> Unit) {
+            threadPool.execute {
+                block()
+            }
+        }
 
         private fun rotate(source: Bitmap, angle: Float): Bitmap {
             val matrix = Matrix()


### PR DESCRIPTION
Fix for the issue: https://github.com/NGhebreial/flutter_exif_rotation/issues/52

`calling rotateImage multiple times from dart size was causing plugin to crash with OutOfMemory exception. Replaced newCachedThreadPool executor with coroutine with main dispatcher. Issue no longer present: no crashing when rotating over 50 images.`


- I tried using IO context for coroutins but it crashes as well.
- With current fix I was able to use the plugin on 50 images. 
- Performance: it took 22 seconds to rotate 50 images on my pixel 4.