### PR TITLE
Make Android and iOS file saving consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.0
+
+* BREAKING CHANGE: Android and iOS now have the same behavior for saving the fixed file. Both overwrite the existing one by default.
+* Added argument to allow specifying an output path to save the fixed image to instead of overwriting the existing one.
+
 ## 0.5.2
 * Upgraded gradle by @javaddehban
 

--- a/android/src/main/kotlin/io/flutter/plugins/flutterexifrotation/FlutterExifRotationPlugin.kt
+++ b/android/src/main/kotlin/io/flutter/plugins/flutterexifrotation/FlutterExifRotationPlugin.kt
@@ -46,6 +46,7 @@ class FlutterExifRotationPlugin : FlutterPlugin, MethodCallHandler {
 
     private fun launchRotateImage(call: MethodCall, result: MethodChannel.Result) {
         val photoPath = call.argument<String>("path")
+        val outputPath = call.argument<String?>("outputPath") ?: photoPath
         val save = argument(call, "save", false)!!
         val orientation: Int
         try {
@@ -65,8 +66,7 @@ class FlutterExifRotationPlugin : FlutterPlugin, MethodCallHandler {
                 ExifInterface.ORIENTATION_NORMAL -> bitmap
                 else -> bitmap
             }
-            val file =
-                File(photoPath) // the File to save , append increasing numeric counter to prevent files from getting overwritten.
+            val file = File(outputPath) 
             val fOut = FileOutputStream(file)
             rotatedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, fOut)
             fOut.flush() // Not really required

--- a/ios/Classes/SwiftFlutterExifRotationPlugin.swift
+++ b/ios/Classes/SwiftFlutterExifRotationPlugin.swift
@@ -17,15 +17,16 @@ public class SwiftFlutterExifRotationPlugin: NSObject, FlutterPlugin {
                 return
             }
             let imagePath = ((args as AnyObject)["path"]! as? String)!
+            let outputPath = (((args as AnyObject)["outputPath"] as? String?) ?? imagePath)!
             let image = UIImage(contentsOfFile: imagePath)
             
             if let updatedImage = image?.updateImageOrientationUpSide() {
                 
                 let fileManager = FileManager.default
-                let imageData = updatedImage.jpegData(compressionQuality: 0.8); fileManager.createFile(atPath: imagePath, contents: imageData, attributes: nil)
-                result(imagePath)
+                let imageData = updatedImage.jpegData(compressionQuality: 0.8); fileManager.createFile(atPath: outputPath, contents: imageData, attributes: nil)
+                result(outputPath)
             } else {
-                result(imagePath)
+                result(outputPath)
             }
         }
     }

--- a/ios/Classes/SwiftFlutterExifRotationPlugin.swift
+++ b/ios/Classes/SwiftFlutterExifRotationPlugin.swift
@@ -22,10 +22,8 @@ public class SwiftFlutterExifRotationPlugin: NSObject, FlutterPlugin {
             if let updatedImage = image?.updateImageOrientationUpSide() {
                 
                 let fileManager = FileManager.default
-                let file_name = NSURL(fileURLWithPath: imagePath).lastPathComponent!
-                let paths = (NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0] as NSString).appendingPathComponent(file_name)
-                let imageData = updatedImage.jpegData(compressionQuality: 0.8); fileManager.createFile(atPath: paths as String, contents: imageData, attributes: nil)
-                result(paths as String)
+                let imageData = updatedImage.jpegData(compressionQuality: 0.8); fileManager.createFile(atPath: imagePath, contents: imageData, attributes: nil)
+                result(imagePath)
             } else {
                 result(imagePath)
             }

--- a/lib/flutter_exif_rotation.dart
+++ b/lib/flutter_exif_rotation.dart
@@ -13,38 +13,48 @@ class FlutterExifRotation {
   }
 
   /// Get the [path] of the image and fix the orientation.
-  /// Return the [File] with the exif data fixed
+  /// The original file is overwritten or saved to
+  /// [outputPath] if provided.
+  /// Return the [File] with the exif data fixed.
   static Future<File> rotateImage({
     required String path,
+    String? outputPath,
   }) async =>
       await _rotateImageInternal(
         path: path,
+        outputPath: outputPath,
         save: false,
       );
 
   /// Get the [path] of the image, fix the orientation and
   /// saves the file in the device.
+  /// The original file is overwritten or saved to
+  /// [outputPath] if provided.
   /// Return the [File] with the exif data fixed
   static Future<File> rotateAndSaveImage({
     required String path,
+    String? outputPath,
   }) async =>
       await _rotateImageInternal(
         path: path,
+        outputPath: outputPath,
         save: true,
       );
 
   static Future<File> _rotateImageInternal({
     required String path,
+    required String? outputPath,
     required bool save,
   }) async {
     String filePath = await (_channel.invokeMethod(
       'rotateImage',
       <String, dynamic>{
         'path': path,
+        'outputPath': outputPath,
         'save': false,
       },
     ));
 
-    return new File(filePath);
+    return File(outputPath ?? filePath);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_exif_rotation
 description:
   Flutter plugin that fixes the picture orientation when it's took in landscape for some devices.
-version: 0.5.2
+version: 0.6.0
 homepage: https://github.com/NGhebreial/flutter_exif_rotation
 repository: https://github.com/NGhebreial/flutter_exif_rotation
 


### PR DESCRIPTION
Currently the plugin has different behavior for saving the fixed image. on Android it overwrites the existing file while on iOS it saves it to the app's internal documents folder. This PR changes it so both overwrite the existing file by default. 

I also added additional arguments to the `rotateImage` functions to specify a different path to save the fixed image to if someone wants to preserve the original image. Hopefully this makes the change in platform behavior more acceptable. 